### PR TITLE
Update DatabaseInitializer to create control table and execute initialization script if necessary

### DIFF
--- a/src/main/java/br/com/lux/config/DatabaseInitializer.java
+++ b/src/main/java/br/com/lux/config/DatabaseInitializer.java
@@ -1,11 +1,16 @@
-
 package br.com.lux.config;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.util.FileCopyUtils;
+
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class DatabaseInitializer implements CommandLineRunner {
@@ -16,10 +21,34 @@ public class DatabaseInitializer implements CommandLineRunner {
     @Override
     public void run(String... args) throws Exception
     {
-        // Reserva Trigger
-        // jdbcTemplate.execute("CREATE TRIGGER reserva_modificada AFTER UPDATE ON Reserva FOR EACH ROW CALL \"br.com.lux.domain.trigger.ReservationTrigger\"");
-        // jdbcTemplate.execute("CREATE TRIGGER reserva_criada AFTER INSERT ON Reserva FOR EACH ROW CALL \"br.com.lux.domain.trigger.ReservationTrigger\"");
+        // Verifica se a tabela de controle existe
+        String checkTableSql = "SELECT COUNT(1) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'INITIALIZATION_CONTROL'";
+        Integer tableExists = jdbcTemplate.queryForObject(checkTableSql, Integer.class);
 
-        // User Trigger
+        // Se a tabela de controle não existe, cria a tabela e executa o script de inicialização
+        if (tableExists == 0)
+        {
+            // Cria a tabela de controle
+            String createTableSql = "CREATE TABLE INITIALIZATION_CONTROL (SCRIPT_NAME VARCHAR(255), EXECUTED BOOLEAN)";
+            jdbcTemplate.execute(createTableSql);
+
+            // Carrega o script SQL do classpath
+            Resource resource = new ClassPathResource("/db/data.sql");
+            Reader reader = new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8);
+            String sqlScript = FileCopyUtils.copyToString(reader);
+
+            // Divide o script em instruções individuais
+            String[] sqlStatements = sqlScript.split(";");
+
+            // Executa cada instrução SQL
+            for (String statement : sqlStatements)
+            {
+                jdbcTemplate.execute(statement);
+            }
+
+            // Insere um registro na tabela de controle para indicar que o script de inicialização foi executado
+            String insertControlRecordSql = "INSERT INTO INITIALIZATION_CONTROL (SCRIPT_NAME, EXECUTED) VALUES ('data.sql', true)";
+            jdbcTemplate.execute(insertControlRecordSql);
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,18 +5,17 @@ spring.application.name=Lux
 spring.h2.console.enabled=true
 
 # DATASOURCE jdbc:h2:~/test
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.url=jdbc:h2:~/lux;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=sa
 
 # SQL
-spring.sql.init.mode=always
-spring.sql.init.data-locations=classpath:/db/data.sql
+spring.sql.init.mode=embedded
 
 # JPA
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
 spring.jpa.defer-datasource-initialization=true
 


### PR DESCRIPTION
The DatabaseInitializer class has been updated to include logic for checking if a control table exists in the database. If the control table does not exist, it creates the table and executes an initialization script. The initialization script is loaded from the classpath and executed using the JdbcTemplate. After executing the script, a record is inserted into the control table to indicate that the script has been executed.

This change ensures that the database is properly initialized with the necessary data when the application starts up.