### PR TITLE
"Add decimal validation for sales price field"

### DIFF
--- a/src/main/java/br/com/lux/config/ValidationConfig.java
+++ b/src/main/java/br/com/lux/config/ValidationConfig.java
@@ -3,8 +3,11 @@ package br.com.lux.config;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 
+import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 @Configuration
 public class ValidationConfig {
@@ -12,5 +15,20 @@ public class ValidationConfig {
     @Bean
     public Validator validator() {
         return (Validator) Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        return messageSource;
+    }
+
+    @Bean
+    public LocalValidatorFactoryBean appValidator(MessageSource messageSource) {
+        LocalValidatorFactoryBean bean = new LocalValidatorFactoryBean();
+        bean.setValidationMessageSource(messageSource);
+        return bean;
     }
 }

--- a/src/main/java/br/com/lux/controller/admin/sales/RegisterSalesController.java
+++ b/src/main/java/br/com/lux/controller/admin/sales/RegisterSalesController.java
@@ -1,9 +1,6 @@
 package br.com.lux.controller.admin.sales;
 
 import br.com.lux.domain.sales.Sales;
-import br.com.lux.domain.user.User;
-import br.com.lux.services.car.CarService;
-import br.com.lux.services.client.ClientService;
 import br.com.lux.services.exception.ServiceException;
 import br.com.lux.services.sales.SalesService;
 import br.com.lux.services.user.UserService;

--- a/src/main/java/br/com/lux/domain/sales/Sales.java
+++ b/src/main/java/br/com/lux/domain/sales/Sales.java
@@ -3,8 +3,12 @@ package br.com.lux.domain.sales;
 import br.com.lux.domain.car.Car;
 import br.com.lux.domain.client.Client;
 import br.com.lux.domain.user.User;
+import br.com.lux.services.validator.annotations.DecimalAnnotation;
+
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+
 import jakarta.validation.constraints.*;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -56,9 +60,8 @@ public class Sales implements Serializable
 
     @NotNull(message = "O preço do carro é obrigatório.")
     @DecimalMin(value = "0.01", message = "O preço do carro não pode ser menor que 0")
-    @DecimalMax(value = "19999999.99", message = "O preço do carro não pode ser maior" +
-            " que " +
-            "19999999.99")
+    @DecimalMax(value = "19999999.99", message = "O preço do carro não pode ser maior que 19999999.99")
     @Column(precision = 10, scale = 2, nullable = false)
+    @DecimalAnnotation(message = "O preço de venda deve ser um número")
     private BigDecimal precovenda;
 }

--- a/src/main/java/br/com/lux/services/validator/annotations/DecimalAnnotation.java
+++ b/src/main/java/br/com/lux/services/validator/annotations/DecimalAnnotation.java
@@ -1,0 +1,18 @@
+package br.com.lux.services.validator.annotations;
+
+import br.com.lux.services.validator.validators.DecimalValidator;
+import jakarta.validation.Payload;
+import jakarta.validation.Constraint;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = DecimalValidator.class)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DecimalAnnotation
+{
+    String message() default "O valor deve ser um número";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/br/com/lux/services/validator/validators/DecimalValidator.java
+++ b/src/main/java/br/com/lux/services/validator/validators/DecimalValidator.java
@@ -1,0 +1,28 @@
+package br.com.lux.services.validator.validators;
+
+import br.com.lux.services.validator.annotations.DecimalAnnotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.math.BigDecimal;
+
+public class DecimalValidator implements ConstraintValidator<DecimalAnnotation, BigDecimal>
+{
+    @Override
+    public void initialize(DecimalAnnotation constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(BigDecimal value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        try {
+            new BigDecimal(value.toString());
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+        return true;
+    }
+}
+

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,1 @@
+typeMismatch.sales.precovenda=Por favor, insira um n\u00FAmero v\u00E1lido. Ex: 123.45 sem , ou R$",


### PR DESCRIPTION
This pull request adds decimal validation for the sales price field in the Sales class. It includes the following changes:

- Added a new annotation, `@DecimalAnnotation`, to validate that the sales price is a decimal number.

- Created a new validator, `DecimalValidator`, to implement the decimal validation logic.

- Updated the Sales class to use the `@DecimalAnnotation` on the `precovenda` field.

- Added a new message to the validation messages file to display a custom error message when the sales price is not a valid decimal number.

These changes ensure that the sales price field only accepts valid decimal numbers, providing better data integrity and user experience.